### PR TITLE
Fixed a param typo in delete movie from watchlist

### DIFF
--- a/routes/watchlists.js
+++ b/routes/watchlists.js
@@ -87,7 +87,7 @@ exports.getWatchlistById = function (req, res) {
 };
 
 exports.removeMovieFromWatchlist = function (req, res) {
-    Watchlist.findById(req.params.watchlistId, function (err, watchlist) {
+    Watchlist.findById(req.params.id, function (err, watchlist) {
         if (!err) {
             if (watchlist) {
                 var movieToRemove = watchlist.movies.filter(function (movie) {


### PR DESCRIPTION
Without this change, the API could not map in the req the watchlist id on the delete action.