### PR TITLE
Bug/user following

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -24,6 +24,10 @@ userSchema.methods.toDTO = function (following) {
 
     if (following) {
         dto.following = obj.following;
+        dto.following.forEach(function (followedUser) {
+            followedUser.id = followedUser._id;
+            delete followedUser._id;
+        });
     }
 
     return dto;

--- a/routes/user.js
+++ b/routes/user.js
@@ -83,7 +83,11 @@ exports.follow = function (req, res) {
     User.findById(req.body.id, function (err, userToFollow) {
         if (!err) {
             if (!req.user.isFollowingUser(userToFollow.id)) {
-                req.user.following.push(userToFollow.toDTO(false));
+                var userToAddInFollowers = userToFollow.toDTO(false);
+                userToAddInFollowers._id = userToAddInFollowers.id;
+                
+                req.user.following.push(userToAddInFollowers);
+                
                 req.user.save(function (err) {
                     if (!err) {
                         res.status(201).send(req.user.toDTO(true));


### PR DESCRIPTION
Hi, 
I've wanted to navigate from friends to friends, but when I was fetching a user, the id of those followed users was not corresponding to an existing user in the collection. 
After investigation, when adding a user it the list of followed user and saving the freshly edited user, I found that Mongo was generating an object id since the newly followed user did not had a _id. 

These changes are fixing this behavior. 